### PR TITLE
Add ability to select attributes

### DIFF
--- a/CONTRIBUTORS.md
+++ b/CONTRIBUTORS.md
@@ -6,6 +6,7 @@ AngleSharp.XPath contains code written by (in order of first pull request / comm
 
 * [Denis Ivanov](https://github.com/denis-ivanov)
 * [Florian Rappl](https://github.com/FlorianRappl)
+* [Richard Robertson](https://github.com/RichardRobertson)
 
 Without these awesome people AngleSharp.XPath could not exist. Thanks to everyone for your contributions! :beers:
 

--- a/src/AngleSharp.XPath.Tests/AngleSharp.XPath.Tests.csproj
+++ b/src/AngleSharp.XPath.Tests/AngleSharp.XPath.Tests.csproj
@@ -1,9 +1,9 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk">
   <ItemGroup>
-    <PackageReference Include="AngleSharp.Xml" Version="0.13.0" />
-    <PackageReference Include="Microsoft.NET.Test.Sdk" Version="16.4.0" />
+    <PackageReference Include="AngleSharp.Xml" Version="0.14.0" />
+    <PackageReference Include="Microsoft.NET.Test.Sdk" Version="16.5.0" />
     <PackageReference Include="NUnit" Version="3.12.0" />
-    <PackageReference Include="NUnit3TestAdapter" Version="3.16.0" />
+    <PackageReference Include="NUnit3TestAdapter" Version="3.16.1" />
   </ItemGroup>
   <ItemGroup>
     <ProjectReference Include="..\AngleSharp.XPath\AngleSharp.XPath.csproj" />

--- a/src/AngleSharp.XPath.Tests/HtmlDocumentNavigatorTests.cs
+++ b/src/AngleSharp.XPath.Tests/HtmlDocumentNavigatorTests.cs
@@ -99,5 +99,22 @@ namespace AngleSharp.XPath.Tests
             Assert.IsNotNull(node);
             Assert.That(node.NodeName, Is.EqualTo("xhtml:link"));
         }
+
+        [Test]
+        public void SelectNodes_CanReturnAttribute()
+        {
+            // Arrange
+            var html = "<!DOCTYPE html><html><body><div class=\"one\"><span class=\"two\">hello world</span></div></body></html>";
+            var parser = new HtmlParser();
+            var doc = parser.ParseDocument(html);
+
+            // Act
+            var nodes = doc.DocumentElement.SelectNodes("//@*");
+
+            // Assert
+            Assert.IsNotNull(nodes);
+            Assert.That(nodes, Has.Count.EqualTo(2));
+            Assert.That(nodes, Is.All.InstanceOf<Dom.IAttr>());
+        }
     }
 }

--- a/src/AngleSharp.XPath/AngleSharp.XPath.csproj
+++ b/src/AngleSharp.XPath/AngleSharp.XPath.csproj
@@ -1,13 +1,13 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk">
   <PropertyGroup>
-    <Version>1.1.6</Version>
+    <Version>1.1.7</Version>
     <Authors>Denis Ivanov</Authors>
     <PackageId>AngleSharp.XPath</PackageId>
-    <AssemblyVersion>1.1.6</AssemblyVersion>
+    <AssemblyVersion>1.1.7</AssemblyVersion>
     <AssemblyName>AngleSharp.XPath</AssemblyName>
     <RootNamespace>AngleSharp.XPath</RootNamespace>
     <TargetFramework>netstandard2.0</TargetFramework>
-    <FileVersion>1.1.6</FileVersion>
+    <FileVersion>1.1.7</FileVersion>
     <Description>XPath support for AngleSharp</Description>
     <PackageProjectUrl>https://github.com/AngleSharp/AngleSharp.XPath/</PackageProjectUrl>
     <PackageLicenseExpression>MIT</PackageLicenseExpression>
@@ -19,7 +19,7 @@
   </PropertyGroup>
 
   <ItemGroup>
-    <PackageReference Include="AngleSharp" Version="0.13.0" />
+    <PackageReference Include="AngleSharp" Version="0.14.0" />
   </ItemGroup>
 
   <PropertyGroup Condition=" '$(OS)' == 'Windows_NT' ">

--- a/src/AngleSharp.XPath/AttrNodeWrapper.cs
+++ b/src/AngleSharp.XPath/AttrNodeWrapper.cs
@@ -1,0 +1,162 @@
+using System;
+using System.IO;
+using AngleSharp.Dom;
+using AngleSharp.Dom.Events;
+
+namespace AngleSharp.XPath
+{
+    internal class AttrNodeWrapper : IAttr, INode
+    {
+        public AttrNodeWrapper(IAttr attribute, IElement parentElement)
+        {
+            Attribute = attribute ?? throw new ArgumentNullException(nameof(attribute));
+            ParentElement = parentElement ?? throw new ArgumentNullException(nameof(parentElement));
+        }
+
+        public IAttr Attribute
+        {
+            get;
+        }
+
+        public string LocalName => Attribute.LocalName;
+
+        public string Name => Attribute.Name;
+
+        public string Value
+        {
+            get => Attribute.Value;
+            set => Attribute.Value = value;
+        }
+
+        public string NamespaceUri => Attribute.NamespaceUri;
+
+        public string Prefix => Attribute.Prefix;
+
+        string INode.BaseUri => null;
+
+        Url INode.BaseUrl => null;
+
+        string INode.NodeName => Attribute.Name;
+
+        INodeList INode.ChildNodes => null;
+
+        IDocument INode.Owner => ParentElement.Owner;
+
+        public IElement ParentElement
+        {
+            get;
+        }
+
+        INode INode.Parent => ParentElement;
+
+        INode INode.FirstChild => null;
+
+        INode INode.LastChild => null;
+
+        INode INode.NextSibling => null;
+
+        INode INode.PreviousSibling => null;
+
+        NodeType INode.NodeType => NodeType.Attribute;
+
+        string INode.NodeValue
+        {
+            get => Value;
+            set => Value = value;
+        }
+
+        string INode.TextContent
+        {
+            get => Value;
+            set => Value = value;
+        }
+
+        bool INode.HasChildNodes => false;
+
+        NodeFlags INode.Flags => NodeFlags.None;
+
+        public bool Equals(IAttr other)
+        {
+            return Attribute.Equals(other);
+        }
+
+        void IEventTarget.AddEventListener(string type, DomEventHandler callback, bool capture)
+        {
+            throw new NotSupportedException();
+        }
+
+        INode INode.AppendChild(INode child)
+        {
+            throw new NotSupportedException();
+        }
+
+        INode INode.Clone(bool deep)
+        {
+            throw new NotSupportedException();
+        }
+
+        DocumentPositions INode.CompareDocumentPosition(INode otherNode)
+        {
+            throw new NotSupportedException();
+        }
+
+        bool INode.Contains(INode otherNode) => false;
+
+        bool IEventTarget.Dispatch(Event ev) => false;
+
+        bool INode.Equals(INode otherNode)
+        {
+            return otherNode is AttrNodeWrapper attrNodeWrapper && Equals(attrNodeWrapper);
+        }
+
+        INode INode.InsertBefore(INode newElement, INode referenceElement)
+        {
+            throw new NotSupportedException();
+        }
+
+        void IEventTarget.InvokeEventListener(Event ev)
+        {
+            throw new NotSupportedException();
+        }
+
+        bool INode.IsDefaultNamespace(string namespaceUri)
+        {
+            throw new NotSupportedException();
+        }
+
+        string INode.LookupNamespaceUri(string prefix)
+        {
+            throw new NotSupportedException();
+        }
+
+        string INode.LookupPrefix(string namespaceUri)
+        {
+            throw new NotSupportedException();
+        }
+
+        void INode.Normalize()
+        {
+            throw new NotSupportedException();
+        }
+
+        INode INode.RemoveChild(INode child)
+        {
+            throw new NotSupportedException();
+        }
+
+        void IEventTarget.RemoveEventListener(string type, DomEventHandler callback, bool capture)
+        {
+            throw new NotSupportedException();
+        }
+
+        INode INode.ReplaceChild(INode newChild, INode oldChild)
+        {
+            throw new NotSupportedException();
+        }
+
+        void IMarkupFormattable.ToHtml(TextWriter writer, IMarkupFormatter formatter)
+        {
+            writer.Write($"{Name}=\"{Value}\"");
+        }
+    }
+}

--- a/src/AngleSharp.XPath/HtmlDocumentNavigator.cs
+++ b/src/AngleSharp.XPath/HtmlDocumentNavigator.cs
@@ -34,7 +34,10 @@ namespace AngleSharp.XPath
         /// <summary>
         /// Gets the currently selected node.
         /// </summary>
-		public INode CurrentNode => _currentNode;
+		public INode CurrentNode =>
+            _attrIndex != -1
+                ? new AttrNodeWrapper(((IElement)_currentNode).Attributes[_attrIndex], (IElement)_currentNode)
+                : _currentNode;
 
         /// <summary>
         /// Gets the currently selected element.
@@ -50,13 +53,13 @@ namespace AngleSharp.XPath
         /// <inheritdoc />
         public override string LocalName =>
             _attrIndex != -1
-                ? NameTable.GetOrAdd(CurrentElement.Attributes[_attrIndex].LocalName)
+                ? NameTable.GetOrAdd(((IAttr)CurrentNode).LocalName)
                 : NameTable.GetOrAdd(CurrentNode is IElement e ? e.LocalName : string.Empty);
 
         /// <inheritdoc />
         public override string Name =>
             _attrIndex != -1
-                ? NameTable.GetOrAdd(CurrentElement.Attributes[_attrIndex].Name)
+                ? NameTable.GetOrAdd(((IAttr)CurrentNode).Name)
                 : NameTable.GetOrAdd(_currentNode.NodeName);
 
         /// <inheritdoc />
@@ -70,7 +73,7 @@ namespace AngleSharp.XPath
                 }
 
                 return _attrIndex != -1
-                    ? NameTable.GetOrAdd(CurrentElement.Attributes[_attrIndex].NamespaceUri ?? string.Empty)
+                    ? NameTable.GetOrAdd(((IAttr)CurrentNode).NamespaceUri ?? string.Empty)
                     : NameTable.GetOrAdd(CurrentElement?.NamespaceUri ?? string.Empty);
             }
         }
@@ -78,7 +81,7 @@ namespace AngleSharp.XPath
         /// <inheritdoc />
         public override string Prefix =>
             _attrIndex != 1
-                ? NameTable.GetOrAdd(CurrentElement.Attributes[_attrIndex].Prefix ?? string.Empty)
+                ? NameTable.GetOrAdd(((IAttr)CurrentNode).Prefix ?? string.Empty)
                 : NameTable.GetOrAdd(CurrentElement?.Prefix ?? string.Empty);
 
         /// <inheritdoc />
@@ -155,7 +158,7 @@ namespace AngleSharp.XPath
 						return documentType.Name;
 
 					case Dom.NodeType.Element:
-						return _attrIndex != -1 ? CurrentElement.Attributes[_attrIndex].Value : _currentNode.TextContent;
+						return _attrIndex != -1 ? ((IAttr)CurrentNode).Value : _currentNode.TextContent;
 
                     case Dom.NodeType.Entity:
 						return _currentNode.TextContent;


### PR DESCRIPTION
Fixes issue #23 (which was closed without actually being fixed).

AngleSharp's IAttr does not implement INode (due to current DOM spec not classifying them as such) so I made a wrapper that implements both IAttr and INode. This allows attributes to be returned from SelectNodes and SelectSingleNode. This changes the behavior of HtmlDocumentNavigator.CurrentNode to construct a wrapper if _attrIndex != -1.

Also added a test to confirm that it can return "nodes" that are instances of IAttr.

This is technically a breaking change if people were relying on the old incorrect behavior of returning the element that owns the attribute instead of the selected attribute itself.