### PR TITLE
Add ability to select attributes

### DIFF
--- a/CONTRIBUTORS.md
+++ b/CONTRIBUTORS.md
@@ -6,6 +6,7 @@ AngleSharp.XPath contains code written by (in order of first pull request / comm
 
 * [Denis Ivanov](https://github.com/denis-ivanov)
 * [Florian Rappl](https://github.com/FlorianRappl)
+* [Richard Robertson](https://github.com/RichardRobertson)
 
 Without these awesome people AngleSharp.XPath could not exist. Thanks to everyone for your contributions! :beers:
 

--- a/src/AngleSharp.XPath.Tests/HtmlDocumentNavigatorTests.cs
+++ b/src/AngleSharp.XPath.Tests/HtmlDocumentNavigatorTests.cs
@@ -99,5 +99,22 @@ namespace AngleSharp.XPath.Tests
             Assert.IsNotNull(node);
             Assert.That(node.NodeName, Is.EqualTo("xhtml:link"));
         }
+
+        [Test]
+        public void SelectNodes_CanReturnAttribute()
+        {
+            // Arrange
+            var html = "<!DOCTYPE html><html><body><div class=\"one\"><span class=\"two\">hello world</span></div></body></html>";
+            var parser = new HtmlParser();
+            var doc = parser.ParseDocument(html);
+
+            // Act
+            var nodes = doc.DocumentElement.SelectNodes("//@*");
+
+            // Assert
+            Assert.IsNotNull(nodes);
+            Assert.That(nodes, Has.Count.EqualTo(2));
+            Assert.That(nodes, Is.All.InstanceOf<Dom.IAttr>());
+        }
     }
 }

--- a/src/AngleSharp.XPath/AttrNodeWrapper.cs
+++ b/src/AngleSharp.XPath/AttrNodeWrapper.cs
@@ -1,0 +1,162 @@
+using System;
+using System.IO;
+using AngleSharp.Dom;
+using AngleSharp.Dom.Events;
+
+namespace AngleSharp.XPath
+{
+    internal class AttrNodeWrapper : IAttr, INode
+    {
+        public AttrNodeWrapper(IAttr attribute, IElement parentElement)
+        {
+            Attribute = attribute ?? throw new ArgumentNullException(nameof(attribute));
+            ParentElement = parentElement ?? throw new ArgumentNullException(nameof(parentElement));
+        }
+
+        public IAttr Attribute
+        {
+            get;
+        }
+
+        public string LocalName => Attribute.LocalName;
+
+        public string Name => Attribute.Name;
+
+        public string Value
+        {
+            get => Attribute.Value;
+            set => Attribute.Value = value;
+        }
+
+        public string NamespaceUri => Attribute.NamespaceUri;
+
+        public string Prefix => Attribute.Prefix;
+
+        string INode.BaseUri => null;
+
+        Url INode.BaseUrl => null;
+
+        string INode.NodeName => Attribute.Name;
+
+        INodeList INode.ChildNodes => null;
+
+        IDocument INode.Owner => ParentElement.Owner;
+
+        public IElement ParentElement
+        {
+            get;
+        }
+
+        INode INode.Parent => ParentElement;
+
+        INode INode.FirstChild => null;
+
+        INode INode.LastChild => null;
+
+        INode INode.NextSibling => null;
+
+        INode INode.PreviousSibling => null;
+
+        NodeType INode.NodeType => NodeType.Attribute;
+
+        string INode.NodeValue
+        {
+            get => Value;
+            set => Value = value;
+        }
+
+        string INode.TextContent
+        {
+            get => Value;
+            set => Value = value;
+        }
+
+        bool INode.HasChildNodes => false;
+
+        NodeFlags INode.Flags => NodeFlags.None;
+
+        public bool Equals(IAttr other)
+        {
+            return Attribute.Equals(other);
+        }
+
+        void IEventTarget.AddEventListener(string type, DomEventHandler callback, bool capture)
+        {
+            throw new NotSupportedException();
+        }
+
+        INode INode.AppendChild(INode child)
+        {
+            throw new NotSupportedException();
+        }
+
+        INode INode.Clone(bool deep)
+        {
+            throw new NotSupportedException();
+        }
+
+        DocumentPositions INode.CompareDocumentPosition(INode otherNode)
+        {
+            throw new NotSupportedException();
+        }
+
+        bool INode.Contains(INode otherNode) => false;
+
+        bool IEventTarget.Dispatch(Event ev) => false;
+
+        bool INode.Equals(INode otherNode)
+        {
+            return otherNode is AttrNodeWrapper attrNodeWrapper && Equals(attrNodeWrapper);
+        }
+
+        INode INode.InsertBefore(INode newElement, INode referenceElement)
+        {
+            throw new NotSupportedException();
+        }
+
+        void IEventTarget.InvokeEventListener(Event ev)
+        {
+            throw new NotSupportedException();
+        }
+
+        bool INode.IsDefaultNamespace(string namespaceUri)
+        {
+            throw new NotSupportedException();
+        }
+
+        string INode.LookupNamespaceUri(string prefix)
+        {
+            throw new NotSupportedException();
+        }
+
+        string INode.LookupPrefix(string namespaceUri)
+        {
+            throw new NotSupportedException();
+        }
+
+        void INode.Normalize()
+        {
+            throw new NotSupportedException();
+        }
+
+        INode INode.RemoveChild(INode child)
+        {
+            throw new NotSupportedException();
+        }
+
+        void IEventTarget.RemoveEventListener(string type, DomEventHandler callback, bool capture)
+        {
+            throw new NotSupportedException();
+        }
+
+        INode INode.ReplaceChild(INode newChild, INode oldChild)
+        {
+            throw new NotSupportedException();
+        }
+
+        void IMarkupFormattable.ToHtml(TextWriter writer, IMarkupFormatter formatter)
+        {
+            writer.Write($"{Name}=\"{Value}\"");
+        }
+    }
+}

--- a/src/AngleSharp.XPath/HtmlDocumentNavigator.cs
+++ b/src/AngleSharp.XPath/HtmlDocumentNavigator.cs
@@ -34,7 +34,10 @@ namespace AngleSharp.XPath
         /// <summary>
         /// Gets the currently selected node.
         /// </summary>
-		public INode CurrentNode => _currentNode;
+		public INode CurrentNode =>
+            _attrIndex != -1
+                ? new AttrNodeWrapper(((IElement)_currentNode).Attributes[_attrIndex], (IElement)_currentNode)
+                : _currentNode;
 
         /// <summary>
         /// Gets the currently selected element.
@@ -50,13 +53,13 @@ namespace AngleSharp.XPath
         /// <inheritdoc />
         public override string LocalName =>
             _attrIndex != -1
-                ? NameTable.GetOrAdd(CurrentElement.Attributes[_attrIndex].LocalName)
+                ? NameTable.GetOrAdd(((IAttr)CurrentNode).LocalName)
                 : NameTable.GetOrAdd(CurrentNode is IElement e ? e.LocalName : string.Empty);
 
         /// <inheritdoc />
         public override string Name =>
             _attrIndex != -1
-                ? NameTable.GetOrAdd(CurrentElement.Attributes[_attrIndex].Name)
+                ? NameTable.GetOrAdd(((IAttr)CurrentNode).Name)
                 : NameTable.GetOrAdd(_currentNode.NodeName);
 
         /// <inheritdoc />
@@ -70,7 +73,7 @@ namespace AngleSharp.XPath
                 }
 
                 return _attrIndex != -1
-                    ? NameTable.GetOrAdd(CurrentElement.Attributes[_attrIndex].NamespaceUri ?? string.Empty)
+                    ? NameTable.GetOrAdd(((IAttr)CurrentNode).NamespaceUri ?? string.Empty)
                     : NameTable.GetOrAdd(CurrentElement?.NamespaceUri ?? string.Empty);
             }
         }
@@ -78,7 +81,7 @@ namespace AngleSharp.XPath
         /// <inheritdoc />
         public override string Prefix =>
             _attrIndex != 1
-                ? NameTable.GetOrAdd(CurrentElement.Attributes[_attrIndex].Prefix ?? string.Empty)
+                ? NameTable.GetOrAdd(((IAttr)CurrentNode).Prefix ?? string.Empty)
                 : NameTable.GetOrAdd(CurrentElement?.Prefix ?? string.Empty);
 
         /// <inheritdoc />
@@ -155,7 +158,7 @@ namespace AngleSharp.XPath
 						return documentType.Name;
 
 					case Dom.NodeType.Element:
-						return _attrIndex != -1 ? CurrentElement.Attributes[_attrIndex].Value : _currentNode.TextContent;
+						return _attrIndex != -1 ? ((IAttr)CurrentNode).Value : _currentNode.TextContent;
 
                     case Dom.NodeType.Entity:
 						return _currentNode.TextContent;


### PR DESCRIPTION
Created AttrNodeWrapper which disguises IAttr as INode and allows it to be returned from SelectNodes and SelectSingleNode.
Modified HtmlDocumentNavigator to use AttrNodeWrapper when _attrIndex != -1.
Added test case to verify that attributes can be selected.

This fixes issue #23 which was closed but not fixed previously.

This is technically a breaking change if people were relying on the old incorrect behavior of returning the element that owns the attribute instead of the selected attribute itself.

Sorry for the last broken pull request, this one is set up right.