### PR TITLE
Fixing and testing MoveToParent to work when reader is positioned on …

### DIFF
--- a/src/AngleSharp.XPath/HtmlDocumentNavigator.cs
+++ b/src/AngleSharp.XPath/HtmlDocumentNavigator.cs
@@ -312,15 +312,22 @@ namespace AngleSharp.XPath
 
         /// <inheritdoc />
         public override bool MoveToParent()
-		{
-			if (_currentNode.Parent == null)
-			{
-				return false;
-			}
+        {
+            if (_currentNode is IAttr attr)
+            {
+                _currentNode = attr.OwnerElement;
+                return true;
+            }
 
-			_currentNode = _currentNode.Parent;
-			return true;
-		}
+            if (_currentNode.Parent == null)
+            {
+                return false;
+            }
+
+            _currentNode = _currentNode.Parent;
+            return true;
+        }
+
 
         /// <inheritdoc />
         public override bool MoveToPrevious()


### PR DESCRIPTION
…attribute node.

Perhaps this helps to make the use of ReadSubtree possible and stable.